### PR TITLE
Bump notifications-ruby-client from 2.9.0 to 5.1.1

### DIFF
--- a/govuk_notify_rails.gemspec
+++ b/govuk_notify_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'rails', '>= 4.1.0'
-  s.add_dependency 'notifications-ruby-client', '>= 2.9.0'
+  s.add_dependency 'notifications-ruby-client', '~> 5.1'
 
   s.add_development_dependency 'bundler', '~> 1.7'
   s.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This updates the [`notifications-ruby-client`](https://github.com/alphagov/notifications-ruby-client) dependency from version 2.9.0 to 5.1.1, and also uses a [pessimistic version constraint operator](https://guides.rubygems.org/patterns/#pessimistic-version-constraint) to guard against future backwards-incompatible 6.x versions of the dependency.

(This PR was motivated by a [dependabot bump](https://github.com/UKGovernmentBEIS/beis-opss/pull/1627/files) of `govuk_notify_rails`  from 2.1.0 to 2.1.1 also bumping `notifications-ruby-client` from 4.0.0 to 5.1.1 and having to manually check whether any significant backwards-incompatible changes were introduced in version 5.x)