### PR TITLE
Bump notifications-ruby-client to 6.2.0

### DIFF
--- a/govuk_notify_rails.gemspec
+++ b/govuk_notify_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'rails', '>= 4.1.0'
-  s.add_dependency 'notifications-ruby-client', '~> 5.1'
+  s.add_dependency 'notifications-ruby-client', '~> 6.2'
 
   s.add_development_dependency 'bundler', '~> 2.2'
   s.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Version 6.2.0 is compatible with this library. The only backwards incompatible change was removing the `is_csv` parameter from `prepare_upload`, which this library does not use.

We want to update to version 6 to make use of the ability to set the file name for file uploads, introduced in version [6.0.0](https://github.com/alphagov/notifications-ruby-client/blob/main/CHANGELOG.md#600).