### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+3.0.0 (08/08/2024)
+==================
+
+* Updated to use latest version of the `notifications-ruby-client` gem (currently [6.2](https://github.com/alphagov/notifications-ruby-client/blob/main/CHANGELOG.md#620)). PR contributed by @stephencdaly.
+* Added support for [one-click unsubscribe URLs](https://docs.notifications.service.gov.uk/ruby.html#one-click-unsubscribe-url-optional). 
+The one-click unsubscribe URL will be added to the headers of your email. Email clients will use it to add an unsubscribe button.
+
+Please note starting with version 6.0 of the client, some breaking changes were introduced to the `prepare_upload` method. 
+Although this gem does not use this method directly, given the `notifications-ruby-client` gem is a transitive dependency, 
+if you are using `prepare_upload` in your code make sure you've made the [necessary changes](https://github.com/alphagov/notifications-ruby-client/blob/main/CHANGELOG.md#600) 
+before updating to this version.
+
 2.2.0 (07/10/2021)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ You can then install the gem or require it in your application.
 gem 'govuk_notify_rails'
 ```
 
-Please note the last version of this gem makes use of the [notifications-ruby-client](https://github.com/alphagov/notifications-ruby-client) gem version >= 2.9.0
+Please note the latest version of this gem makes use of the [notifications-ruby-client](https://github.com/alphagov/notifications-ruby-client) gem version ~> 6.2
 
-You can use a specific version in your Gemfile if you want, granting there are no breaking changes in the interface.
+You can use a specific client version in your Gemfile if you want, granting there are no breaking changes in the interface.
 
 In your app, you will need to add the delivery method, and set the `api_key`, for example with an initializer:
 
@@ -39,10 +39,11 @@ class NotifyMailer < GovukNotifyRails::Mailer
   def my_test_email(user)
     set_template('uuid')
 
-    # Optionally, you can set a reference and a reply_to
+    # Optionally, you can set a reference, a reply_to and an unsubscribe url
     # 
     set_reference('my_reference_string')
     set_email_reply_to('uuid')
+    set_one_click_unsubscribe_url('https://example.com/unsubscribe?token=123456')
     
     set_personalisation(
       full_name: user.full_name,
@@ -104,4 +105,4 @@ Bug reports and pull requests are welcome.
 
 ## License
 
-Released under the [MIT License](http://www.opensource.org/licenses/MIT). Copyright (c) 2015-2020 Ministry of Justice.
+Released under the [MIT License](http://www.opensource.org/licenses/MIT). Copyright (c) 2015-2024 Ministry of Justice.

--- a/lib/govuk_notify_rails/delivery.rb
+++ b/lib/govuk_notify_rails/delivery.rb
@@ -34,7 +34,8 @@ module GovukNotifyRails
         template_id: message.govuk_notify_template,
         reference: message.govuk_notify_reference,
         personalisation: message.govuk_notify_personalisation,
-        email_reply_to_id: message.govuk_notify_email_reply_to
+        email_reply_to_id: message.govuk_notify_email_reply_to,
+        one_click_unsubscribe_url: message.govuk_notify_one_click_unsubscribe_url
       }.compact
     end
 

--- a/lib/govuk_notify_rails/mail_ext.rb
+++ b/lib/govuk_notify_rails/mail_ext.rb
@@ -2,9 +2,12 @@ module Mail
   class Message
     attr_accessor :govuk_notify_template
     attr_accessor :govuk_notify_reference
+    attr_accessor :govuk_notify_email_reply_to
+    attr_accessor :govuk_notify_one_click_unsubscribe_url
+
     attr_accessor :govuk_notify_personalisation
+
     attr_accessor :govuk_notify_response
     attr_accessor :govuk_notify_responses
-    attr_accessor :govuk_notify_email_reply_to
   end
 end

--- a/lib/govuk_notify_rails/mailer.rb
+++ b/lib/govuk_notify_rails/mailer.rb
@@ -6,6 +6,7 @@ module GovukNotifyRails
     attr_accessor :govuk_notify_reference
     attr_accessor :govuk_notify_personalisation
     attr_accessor :govuk_notify_email_reply_to
+    attr_accessor :govuk_notify_one_click_unsubscribe_url
 
     protected
 
@@ -19,6 +20,7 @@ module GovukNotifyRails
       message.govuk_notify_reference = govuk_notify_reference
       message.govuk_notify_personalisation = govuk_notify_personalisation
       message.govuk_notify_email_reply_to = govuk_notify_email_reply_to
+      message.govuk_notify_one_click_unsubscribe_url = govuk_notify_one_click_unsubscribe_url
     end
 
     def set_template(template)
@@ -35,6 +37,10 @@ module GovukNotifyRails
 
     def set_email_reply_to(address)
       self.govuk_notify_email_reply_to = address
+    end
+
+    def set_one_click_unsubscribe_url(url)
+      self.govuk_notify_one_click_unsubscribe_url = url
     end
 
     def _default_body

--- a/lib/govuk_notify_rails/version.rb
+++ b/lib/govuk_notify_rails/version.rb
@@ -1,3 +1,3 @@
 module GovukNotifyRails
-  VERSION = '2.2.0'.freeze
+  VERSION = '3.0.0'.freeze
 end

--- a/spec/dummy/app/mailers/notify_mailer.rb
+++ b/spec/dummy/app/mailers/notify_mailer.rb
@@ -2,6 +2,9 @@ class NotifyMailer < GovukNotifyRails::Mailer
   def test_email(user)
     set_template('9661d08a-486d-4c67-865e-ad976f17871d')
     set_reference('my_reference')
+    set_email_reply_to('527c131f-ef4b-4b5b-8f9b-3202581af277')
+    set_one_click_unsubscribe_url('https://example.com/unsubscribe?token=123456')
+
     set_personalisation(
       full_name: user.name
     )

--- a/spec/govuk_notify_delivery/delivery_spec.rb
+++ b/spec/govuk_notify_delivery/delivery_spec.rb
@@ -5,11 +5,13 @@ describe GovukNotifyRails::Delivery do
   describe '#deliver!' do
     let(:api_key) { 'api-key' }
     let(:notify_client) { double('NotifyClient') }
-    let(:reply_to) { "email_reply_to_reference" }
-
     let(:to) { ['email@example.com'] }
-    let(:personalisation) { { name: 'John' } }
+
     let(:reference) { 'my_reference' }
+    let(:reply_to) { 'email_reply_to_uuid' }
+    let(:unsubscribe_url) { 'https://example.com/unsubscribe?token=123456' }
+
+    let(:personalisation) { { name: 'John' } }
 
     let(:message) do
       instance_double(
@@ -17,8 +19,9 @@ describe GovukNotifyRails::Delivery do
         to: to,
         govuk_notify_template: 'template-123',
         govuk_notify_reference: reference,
-        govuk_notify_personalisation: personalisation,
-        govuk_notify_email_reply_to: reply_to
+        govuk_notify_email_reply_to: reply_to,
+        govuk_notify_one_click_unsubscribe_url: unsubscribe_url,
+        govuk_notify_personalisation: personalisation
       )
     end
 
@@ -37,8 +40,9 @@ describe GovukNotifyRails::Delivery do
           email_address: 'email@example.com',
           template_id: 'template-123',
           reference: reference,
-          personalisation: personalisation,
-          email_reply_to_id: reply_to
+          email_reply_to_id: reply_to,
+          one_click_unsubscribe_url: unsubscribe_url,
+          personalisation: personalisation
         }
       )
 
@@ -105,7 +109,8 @@ describe GovukNotifyRails::Delivery do
             email_address: 'email@example.com',
             template_id: 'template-123',
             reference: reference,
-            email_reply_to_id: "email_reply_to_reference"
+            email_reply_to_id: reply_to,
+            one_click_unsubscribe_url: unsubscribe_url
           }
         )
         subject.deliver!(message)
@@ -121,7 +126,8 @@ describe GovukNotifyRails::Delivery do
             email_address: 'email@example.com',
             template_id: 'template-123',
             personalisation: personalisation,
-            email_reply_to_id: "email_reply_to_reference"
+            email_reply_to_id: reply_to,
+            one_click_unsubscribe_url: unsubscribe_url
           }
         )
         subject.deliver!(message)
@@ -137,7 +143,25 @@ describe GovukNotifyRails::Delivery do
             email_address: 'email@example.com',
             template_id: 'template-123',
             personalisation: personalisation,
-            reference: reference
+            reference: reference,
+            one_click_unsubscribe_url: unsubscribe_url
+          }
+        )
+        subject.deliver!(message)
+      end
+    end
+
+    context 'no unsubscribe url set' do
+      let(:unsubscribe_url) { nil }
+
+      it 'supports messages without unsubscribe url' do
+        expect(notify_client).to receive(:send_email).with(
+          {
+            email_address: 'email@example.com',
+            template_id: 'template-123',
+            reference: reference,
+            email_reply_to_id: reply_to,
+            personalisation: personalisation
           }
         )
         subject.deliver!(message)

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe NotifyMailer, type: :mailer do
   describe 'new_message_test_email' do
     let(:template) { '9661d08a-486d-4c67-865e-ad976f17871d' }
     let(:reference) { 'my_reference' }
+    let(:reply_to) { '527c131f-ef4b-4b5b-8f9b-3202581af277' }
+    let(:unsubscribe_url) { 'https://example.com/unsubscribe?token=123456' }
+
     let(:user) { double('User', name: 'Test Name', email: 'test@example.com') }
     let(:mail) { described_class.test_email(user) }
 
@@ -26,6 +29,14 @@ RSpec.describe NotifyMailer, type: :mailer do
 
     it 'sets the reference' do
       expect(mail.govuk_notify_reference).to eq(reference)
+    end
+
+    it 'sets the reply_to' do
+      expect(mail.govuk_notify_email_reply_to).to eq(reply_to)
+    end
+
+    it 'sets the unsubscribe url' do
+      expect(mail.govuk_notify_one_click_unsubscribe_url).to eq(unsubscribe_url)
     end
 
     it 'sets the personalisation' do


### PR DESCRIPTION
This version will start using latest version of the `notifications-ruby-client` (currently 6.2)

It includes some changes that might be worth considering before you update. Please refer to the changelog.